### PR TITLE
added caddy to fix cors issues for local testing

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,4 @@
+:3623 {
+    reverse_proxy authfox:3621
+    header Access-Control-Allow-Origin *
+}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     ports:
       - 6379:6379
   authfox:
-    build: .
+    build: ../
     restart: unless-stopped
     environment:
       - POSTGRES_HOST=postgres
@@ -41,3 +41,9 @@ services:
       - 3622:3621
     depends_on:
       - postgres
+  caddy:
+    image: caddy:latest
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:z
+    ports:
+      - 3623:3623


### PR DESCRIPTION
This adds the caddy reverse proxy for setting the CORS header so we can test authfox with a front-end locally.